### PR TITLE
Fix withOpacity usage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,4 @@ app.*.map.json
 /android/app/debug
 /android/app/profile
 /android/app/release
+/flutter/

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -85,7 +85,7 @@ class _MyAppState extends State<MyApp> with WidgetsBindingObserver {
                     final opacity = 0.7 * (1 - settings.brightness);
                     return IgnorePointer(
                       child: Container(
-                        color: Colors.black.withValues(alpha: opacity),
+                        color: Colors.black.withOpacity(opacity),
                       ),
                     );
                   },

--- a/lib/screens/credits_screen.dart
+++ b/lib/screens/credits_screen.dart
@@ -46,7 +46,7 @@ class CreditsScreen extends StatelessWidget {
                   margin: const EdgeInsets.all(20),
                   padding: const EdgeInsets.all(30),
                   decoration: BoxDecoration(
-                    color: Colors.black.withValues(alpha: 0.5),
+                    color: Colors.black.withOpacity(0.5),
                     borderRadius: BorderRadius.circular(15),
                   ),
                   child: Column(

--- a/lib/screens/games/bad_descriptions_game_screen.dart
+++ b/lib/screens/games/bad_descriptions_game_screen.dart
@@ -82,7 +82,7 @@ class _BadDescriptionsGameScreenState extends State<BadDescriptionsGameScreen> {
                   margin: const EdgeInsets.all(20),
                   padding: const EdgeInsets.all(30),
                   decoration: BoxDecoration(
-                    color: Colors.black.withValues(alpha: 0.5),
+                    color: Colors.black.withOpacity(0.5),
                     borderRadius: BorderRadius.circular(15),
                   ),
                   child: Column(
@@ -91,9 +91,9 @@ class _BadDescriptionsGameScreenState extends State<BadDescriptionsGameScreen> {
                       Container(
                         padding: const EdgeInsets.all(20),
                         decoration: BoxDecoration(
-                          color: Colors.white.withValues(alpha: 0.1),
+                          color: Colors.white.withOpacity(0.1),
                           borderRadius: BorderRadius.circular(10),
-                          border: Border.all(color: Colors.deepPurple.withValues(alpha: 0.5)),
+                          border: Border.all(color: Colors.deepPurple.withOpacity(0.5)),
                         ),
                         child: Text(
                           '${l10n.get('to_implement')}\n\nQui apparirà una descrizione fuorviante di un\'opera...',
@@ -112,9 +112,9 @@ class _BadDescriptionsGameScreenState extends State<BadDescriptionsGameScreen> {
                         style: const TextStyle(color: Colors.white),
                         decoration: InputDecoration(
                           hintText: 'Inserisci la tua risposta...',
-                          hintStyle: TextStyle(color: Colors.white.withValues(alpha: 0.5)),
+                          hintStyle: TextStyle(color: Colors.white.withOpacity(0.5)),
                           filled: true,
-                          fillColor: Colors.white.withValues(alpha: 0.1),
+                          fillColor: Colors.white.withOpacity(0.1),
                           border: OutlineInputBorder(
                             borderRadius: BorderRadius.circular(10),
                             borderSide: const BorderSide(color: Colors.deepPurple),

--- a/lib/screens/games/bad_images_game_screen.dart
+++ b/lib/screens/games/bad_images_game_screen.dart
@@ -82,7 +82,7 @@ class _BadImagesGameScreenState extends State<BadImagesGameScreen> {
                   margin: const EdgeInsets.all(20),
                   padding: const EdgeInsets.all(30),
                   decoration: BoxDecoration(
-                    color: Colors.black.withValues(alpha: 0.5),
+                    color: Colors.black.withOpacity(0.5),
                     borderRadius: BorderRadius.circular(15),
                   ),
                   child: Column(
@@ -92,7 +92,7 @@ class _BadImagesGameScreenState extends State<BadImagesGameScreen> {
                         width: 250,
                         height: 250,
                         decoration: BoxDecoration(
-                          color: Colors.grey.withValues(alpha: 0.3),
+                          color: Colors.grey.withOpacity(0.3),
                           borderRadius: BorderRadius.circular(10),
                           border: Border.all(color: Colors.grey),
                         ),
@@ -111,9 +111,9 @@ class _BadImagesGameScreenState extends State<BadImagesGameScreen> {
                         style: const TextStyle(color: Colors.white),
                         decoration: InputDecoration(
                           hintText: l10n.get('to_implement'),
-                          hintStyle: TextStyle(color: Colors.white.withValues(alpha: 0.5)),
+                          hintStyle: TextStyle(color: Colors.white.withOpacity(0.5)),
                           filled: true,
-                          fillColor: Colors.white.withValues(alpha: 0.1),
+                          fillColor: Colors.white.withOpacity(0.1),
                           border: OutlineInputBorder(
                             borderRadius: BorderRadius.circular(10),
                             borderSide: const BorderSide(color: Colors.deepPurple),

--- a/lib/screens/games/game_screen.dart
+++ b/lib/screens/games/game_screen.dart
@@ -285,7 +285,7 @@ class _GameScreenState extends State<GameScreen> {
               Container(
                 padding: const EdgeInsets.all(20),
                 decoration: BoxDecoration(
-                  color: Colors.purple.withValues(alpha: 0.3),
+                  color: Colors.purple.withOpacity(0.3),
                   borderRadius: BorderRadius.circular(15),
                 ),
                 child: Column(
@@ -493,7 +493,7 @@ class _GameScreenState extends State<GameScreen> {
                       Container(
                         padding: const EdgeInsets.symmetric(horizontal: 15, vertical: 8),
                         decoration: BoxDecoration(
-                          color: Colors.purple.withValues(alpha: 0.7),
+                          color: Colors.purple.withOpacity(0.7),
                           borderRadius: BorderRadius.circular(20),
                         ),
                         child: Text(
@@ -535,9 +535,9 @@ class _GameScreenState extends State<GameScreen> {
                     margin: const EdgeInsets.all(20),
                     padding: const EdgeInsets.all(25),
                     decoration: BoxDecoration(
-                      color: Colors.black.withValues(alpha: 0.7),
+                      color: Colors.black.withOpacity(0.7),
                       borderRadius: BorderRadius.circular(20),
-                      border: Border.all(color: Colors.purple.withValues(alpha: 0.5), width: 2),
+                      border: Border.all(color: Colors.purple.withOpacity(0.5), width: 2),
                     ),
                     child: Column(
                       mainAxisAlignment: MainAxisAlignment.center,
@@ -547,7 +547,7 @@ class _GameScreenState extends State<GameScreen> {
                           Container(
                             padding: const EdgeInsets.symmetric(horizontal: 15, vertical: 8),
                             decoration: BoxDecoration(
-                              color: Colors.purple.withValues(alpha: 0.3),
+                              color: Colors.purple.withOpacity(0.3),
                               borderRadius: BorderRadius.circular(15),
                             ),
                             child: Text(
@@ -680,7 +680,7 @@ class _GameScreenState extends State<GameScreen> {
           child: ElevatedButton(
             onPressed: _showingFeedback ? null : () => _handleMultipleChoiceAnswer(index),
             style: ElevatedButton.styleFrom(
-              backgroundColor: buttonColor.withValues(alpha: 0.3),
+              backgroundColor: buttonColor.withOpacity(0.3),
               padding: const EdgeInsets.all(16),
               shape: RoundedRectangleBorder(
                 borderRadius: BorderRadius.circular(15),

--- a/lib/screens/profile_screen.dart
+++ b/lib/screens/profile_screen.dart
@@ -47,7 +47,7 @@ class ProfileScreen extends StatelessWidget {
                   margin: const EdgeInsets.all(20),
                   padding: const EdgeInsets.all(30),
                   decoration: BoxDecoration(
-                    color: Colors.black.withValues(alpha: 0.5),
+                    color: Colors.black.withOpacity(0.5),
                     borderRadius: BorderRadius.circular(15),
                   ),
                   child: Column(

--- a/lib/screens/settings_screen.dart
+++ b/lib/screens/settings_screen.dart
@@ -50,7 +50,7 @@ class SettingsScreen extends StatelessWidget {
                   Container(
                     padding: const EdgeInsets.all(20),
                     decoration: BoxDecoration(
-                      color: Colors.black.withValues(alpha: 0.5),
+                      color: Colors.black.withOpacity(0.5),
                       borderRadius: BorderRadius.circular(10),
                     ),
                     child: Column(
@@ -97,7 +97,7 @@ class SettingsScreen extends StatelessWidget {
                   Container(
                     padding: const EdgeInsets.all(20),
                     decoration: BoxDecoration(
-                      color: Colors.black.withValues(alpha: 0.5),
+                      color: Colors.black.withOpacity(0.5),
                       borderRadius: BorderRadius.circular(10),
                     ),
                     child: Column(
@@ -146,7 +146,7 @@ class SettingsScreen extends StatelessWidget {
                   Container(
                     padding: const EdgeInsets.all(20),
                     decoration: BoxDecoration(
-                      color: Colors.black.withValues(alpha: 0.5),
+                      color: Colors.black.withOpacity(0.5),
                       borderRadius: BorderRadius.circular(10),
                     ),
                     child: Column(
@@ -192,7 +192,7 @@ class SettingsScreen extends StatelessWidget {
                   Container(
                     padding: const EdgeInsets.all(20),
                     decoration: BoxDecoration(
-                      color: Colors.black.withValues(alpha: 0.5),
+                      color: Colors.black.withOpacity(0.5),
                       borderRadius: BorderRadius.circular(10),
                     ),
                     child: Column(


### PR DESCRIPTION
## Summary
- replace deprecated `withValues()` method with `withOpacity()` across the app
- ignore a vendor Flutter SDK checkout

## Testing
- `grep -R "withValues(" -n lib`
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68668a536158832fb9b5ddcd6831b2d5